### PR TITLE
import :std/assert

### DIFF
--- a/db.ss
+++ b/db.ss
@@ -49,7 +49,7 @@
 (import
   :gerbil/gambit/threads
   :std/db/leveldb
-  :std/misc/completion :std/misc/list :std/misc/number :std/sugar
+  :std/misc/completion :std/misc/list :std/misc/number :std/sugar :std/assert
   :clan/base :clan/concurrency :clan/path :clan/path-config)
 
 (defstruct DbConnection

--- a/db.ss
+++ b/db.ss
@@ -49,7 +49,9 @@
 (import
   :gerbil/gambit/threads
   :std/db/leveldb
-  :std/misc/completion :std/misc/list :std/misc/number :std/sugar :std/assert
+  :std/assert
+  :std/misc/completion :std/misc/list :std/misc/number
+  :std/sugar
   :clan/base :clan/concurrency :clan/path :clan/path-config)
 
 (defstruct DbConnection

--- a/persist.ss
+++ b/persist.ss
@@ -3,7 +3,7 @@
 (import
   (for-syntax :clan/syntax)
   :gerbil/gambit/bytes :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/misc/completion :std/misc/hash :std/sugar
+  :std/format :std/misc/completion :std/misc/hash :std/sugar :std/assert
   :clan/base :clan/concurrency :clan/string
   :clan/poo/object :clan/poo/mop :clan/poo/io :clan/poo/type
   :clan/debug :clan/poo/debug

--- a/persist.ss
+++ b/persist.ss
@@ -3,7 +3,9 @@
 (import
   (for-syntax :clan/syntax)
   :gerbil/gambit/bytes :gerbil/gambit/ports :gerbil/gambit/threads
-  :std/format :std/misc/completion :std/misc/hash :std/sugar :std/assert
+  :std/assert :std/format
+  :std/misc/completion :std/misc/hash
+  :std/sugar
   :clan/base :clan/concurrency :clan/string
   :clan/poo/object :clan/poo/mop :clan/poo/io :clan/poo/type
   :clan/debug :clan/poo/debug

--- a/t/db-integrationtest.ss
+++ b/t/db-integrationtest.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/random
-  :std/sugar :std/test
+  :std/sugar :std/assert :std/test
   :std/format :std/misc/list :std/misc/repr
   :clan/concurrency :clan/number :clan/path-config
   ../db)

--- a/t/db-integrationtest.ss
+++ b/t/db-integrationtest.ss
@@ -2,8 +2,9 @@
 
 (import
   :gerbil/gambit/random
-  :std/sugar :std/assert :std/test
-  :std/format :std/misc/list :std/misc/repr
+  :std/assert :std/format
+  :std/misc/list :std/misc/repr
+  :std/sugar :std/test
   :clan/concurrency :clan/number :clan/path-config
   ../db)
 


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/644, `assert!` has been moved from `:std/sugar` to a new module `:std/assert`, so we need to import `:std/assert`.